### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.8']
 
     steps:
       - uses: actions/checkout@master


### PR DESCRIPTION
The remote and local Python versions mismatched. We pin the remote version now to 3.8.